### PR TITLE
chore(utils): remove deprecate tag added to old methods

### DIFF
--- a/packages/utils/src/ts-eslint/Rule.ts
+++ b/packages/utils/src/ts-eslint/Rule.ts
@@ -220,7 +220,6 @@ interface RuleContext<
    * Returns the current working directory passed to Linter.
    * It is a path to a directory that should be considered as the current working directory.
    * @since 6.6.0
-   * @deprecated Use {@link `cwd`} instead.
    */
   getCwd(): string;
 
@@ -233,7 +232,6 @@ interface RuleContext<
 
   /**
    * Returns the filename associated with the source.
-   * @deprecated Use {@link `filename`} instead.
    */
   getFilename(): string;
 
@@ -246,7 +244,6 @@ interface RuleContext<
   /**
    * Returns the full path of the file on disk without any code block information (unlike `getFilename()`).
    * @since 7.28.0
-   * @deprecated Use {@link `physicalFilename`} instead.
    */
   getPhysicalFilename?(): string;
 
@@ -265,7 +262,6 @@ interface RuleContext<
   /**
    * Returns a SourceCode object that you can use to work with the source that
    * was passed to ESLint.
-   * @deprecated Use {@link `sourceCode`} instead.
    */
   getSourceCode(): Readonly<SourceCode>;
 


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Removes those `@deprecated` tags, suggested by @bradzacher